### PR TITLE
Generalize Quadruples to apply to any type conforming to Floating

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ Please read file `tutorial.md` for first steps in using the template.
 [ ] Refactor internal implementation to use a list, which will allow more expresiveness in algorithms 
 
 
+In this branch (generalization-attempt) I tried to make *Quadruple* not be bound to *Double*, but to use any type conforming to *Floating* (that is, *Double* or *Float*). This triggered a series of warnings about how the compiler was defaulting to using *Double*, but warnings are treated as errors and thus tests can't be built and run. Disabling `-WError` makes tests build and pass. See https://www.haskell.org/tutorial/numbers.html#sect10.4 https://www.haskell.org/onlinereport/decls.html#default-decls
+
+If we force-cast all numbers used as function parameters to Double (as in the first test), or the first occurence in each `shouldBe`, then no warnings are raised. However, that much verbosity makes the code cumbersome to write and read. Therefore, we selectively disable those warnings with `{-# OPTIONS_GHC -fno-warn-type-defaults #-}`

--- a/src-exe/Main.hs
+++ b/src-exe/Main.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Quadruple
 
 main :: IO ()

--- a/src-test/Main.hs
+++ b/src-test/Main.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+
 import Test.Tasty
 import Test.Tasty.Hspec
 
@@ -14,9 +16,9 @@ testSuite :: Spec
 testSuite = do
   describe "Tuples components" $ do
     describe "A tuple with w == 1.0 is a point" $ do
-      let p = Quadruple 4.3 (-4.2) 3.1 1.0
+      let p = Quadruple (4.3 :: Double) ((-4.2) :: Double) (3.1 :: Double) (1.0 :: Double)
       it "x == 4.3" $
-        x p `shouldBe` 4.3
+        x p `shouldBe` (4.3 :: Double)
       it "y == -4.2" $
         y p `shouldBe` (-4.2)
       it "z == 3.1" $
@@ -162,9 +164,9 @@ testSuite = do
   describe "Cross Product" $ do
     describe "Cross product of two vectors" $ do
       let a = vector 1 2 3
-      let b = vector 2 3 4
+      let b = vector 2.0 3.0 4.0
       it "a ⨯ b = vector(-1, 2, -1)" $
-        a ⨯ b `shouldBe` vector (-1) 2 (-1)
+        a ⨯ b `shouldBe` vector (-1.0) 2.0 (-1.0)
       it "b ⨯ a = vector(1, -2, 1)" $
         b ⨯ a `shouldBe` vector 1 (-2) 1
 

--- a/src/Projectile.hs
+++ b/src/Projectile.hs
@@ -8,9 +8,9 @@ module Projectile
 
 import Quadruple
 
-data World = World { gravity, wind :: Quadruple} deriving (Eq, Show)
+data World = World { gravity, wind :: Quadruple Double} deriving (Eq, Show)
 
-data Projectile = Projectile { position, velocity :: Quadruple} deriving (Eq, Show)
+data Projectile = Projectile { position, velocity :: Quadruple Double} deriving (Eq, Show)
 
 tick :: World -> Projectile -> Projectile
 tick world p0 = Projectile { position = position p0 + velocity p0, velocity = velocity p0 + gravity world + wind world }

--- a/src/Quadruple.hs
+++ b/src/Quadruple.hs
@@ -18,43 +18,43 @@ module Quadruple
 
 
 
-data Quadruple = Quadruple { x, y, z, w :: Double } deriving (Eq, Show)
+data Quadruple a = Quadruple { x, y, z, w :: a } deriving (Eq, Show)
 
-qmap :: Quadruple -> (Double -> Double) -> Quadruple
+qmap :: (Floating a) => Quadruple a -> (a -> a) -> Quadruple a
 qmap q fn = Quadruple (fn (x q)) (fn (y q)) (fn (z q)) (fn (w q))
 
-toList :: Quadruple -> [Double]
+toList :: (Floating a) => Quadruple a -> [a]
 toList Quadruple { x = x1,  y = y1, z = z1, w = w1 } = [x1, y1, z1, w1]
 
-fromList :: [Double] -> Quadruple
+fromList :: (Floating a) => [a] -> Quadruple a
 fromList [a, b, c, d] = (Quadruple {x = a, y = b, z = c, w = d})
 fromList _ = undefined
 
-point :: Double -> Double -> Double -> Quadruple
+point :: (Floating a) => a -> a -> a -> Quadruple a
 point a b c = Quadruple {x = a, y = b, z = c, w = 1.0}
 
-vector :: Double -> Double -> Double -> Quadruple
+vector :: (Floating a) => a -> a -> a -> Quadruple a
 vector a b c = Quadruple {x = a, y = b, z = c, w = 0.0}
 
-isPoint :: Quadruple -> Bool
-isPoint Quadruple{w = f} = case f of 1.0  -> True
-                                     _ -> False
+isPoint :: (Floating a, Eq a) => Quadruple a -> Bool
+isPoint Quadruple {w = f} = case f of 1.0  -> True
+                                      _ -> False
 
 
-isVector :: Quadruple -> Bool
+isVector :: (Floating a, Eq a) => Quadruple a -> Bool
 isVector q = w q == 0.0
 
-(*|) :: Double -> Quadruple -> Quadruple
+(*|) :: (Floating a) => a -> Quadruple a -> Quadruple a
 (*|) f q1 = qmap q1 (* f)
 
-(|*) :: Quadruple -> Double -> Quadruple
+(|*) :: (Floating a) => Quadruple a -> a -> Quadruple a
 (|*) q1 f = f *| q1
 
-(÷) :: Quadruple -> Double -> Quadruple
+(÷) :: (Floating a) => Quadruple a -> a -> Quadruple a
 (÷) q1 d = qmap q1 (/ d)
 
 
-instance Num Quadruple where
+instance Floating a => Num (Quadruple a) where
   q1 + q2 = fromList (zipWith (+) (toList (q1)) (toList (q2)))
   Quadruple _ _ _ _  * Quadruple _ _ _ _ = undefined
   abs (Quadruple _ _ _ _) = undefined
@@ -63,17 +63,17 @@ instance Num Quadruple where
   negate a = qmap a negate
 
 
-magnitude :: Quadruple -> Double
+magnitude :: (Floating a) => Quadruple a -> a
 magnitude q = sqrt ((x q)**2 + (y q)**2 + (z q)**2)
 
-normalize :: Quadruple -> Quadruple
+normalize :: (Floating a) => Quadruple a -> Quadruple a
 normalize q = qmap q ( / magnitude q)
 
-dot :: Quadruple -> Quadruple -> Double
+dot :: (Floating a) => Quadruple a -> Quadruple a -> a
 dot a b = ((x a) * (x b)) +
   ((y a) * (y b)) +
   ((z a) * (z b)) +
   ((w a) * (w b))
 
-(⨯) :: Quadruple -> Quadruple -> Quadruple
+(⨯) :: (Floating a) => Quadruple a -> Quadruple a -> Quadruple a
 (⨯) a b = vector (((y a)*(z b))-((z a)*(y b))) (((z a)*(x b))-((x a)*(z b))) (((x a)*(y b))-((y a)*(x b)))


### PR DESCRIPTION
As per the subject line, make Quadruple not be hardcoded on Doubles, and be generic instead. Any type conforming to Floating (i.e., Float and Double) can work with it.

Since the tests use numeric literals that can be interpreted as Int, Float or Double, I had to disable some warnings that this triggered, otherwise we'd need to qualify each literal with a cast to Double, which makes the code cumbersome.